### PR TITLE
fix: remove maximum-scale from viewport meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,8 +54,6 @@ export const metadata: Metadata = {
 export const viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
- `maximum-scale=1` can cause issues with accessibilty - and is ignored by modern browsers anyway.
- No need to mention `user-scalable=1` as that is the default.

From AXE-Core Devtools extension
![image](https://github.com/addyosmani/chatty/assets/1212885/8397fc3e-ec9d-47b5-804e-8d3d5072767d)
