### PR TITLE
fix: add check for gpu acceleration compatibility as soon as engine i…

### DIFF
--- a/src/lib/web-llm-helper.ts
+++ b/src/lib/web-llm-helper.ts
@@ -37,6 +37,10 @@ export default class WebLLMHelper {
   public async initialize(
     selectedModel: Model
   ): Promise<webllm.EngineInterface> {
+    if (!("gpu" in navigator)) {
+      return Promise.reject("This device does not support GPU acceleration.");
+    }
+
     this.setStoredMessages((message) => [
       ...message.slice(0, -1),
       {


### PR DESCRIPTION
 As soon as engine is initialized, check for gpu acceleration compatibility so users get response if their device is compatible asap.