### PR TITLE
fix: add gap above change name button

### DIFF
--- a/src/components/edit-username-form.tsx
+++ b/src/components/edit-username-form.tsx
@@ -68,14 +68,14 @@ export default function EditUsernameForm({ setOpen }: EditUsernameFormProps) {
             <FormItem>
               <FormLabel>Name</FormLabel>
               <FormControl>
-                <div className="md:flex gap-4">
+                <div className="md:flex md:gap-4 space-y-4 md:space-y-0">
                   <Input
                     {...field}
                     type="text"
                     value={name}
                     onChange={(e) => handleChange(e)}
                   />
-                  <Button type="submit">Change name</Button>
+                  <Button type="submit" className="w-full md:w-fit">Change name</Button>
                 </div>
               </FormControl>
               <FormMessage />


### PR DESCRIPTION
This PR should fix #51 . It adds a gap between change name button and its related input (name input) when the screen width is smaller than 768px.